### PR TITLE
chore: bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@edx/frontend-platform",
-  "version": "7.1.2-alpha.1",
+  "name": "@edunext/frontend-platform",
+  "version": "7.1.2-alpha-nelc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@edx/frontend-platform",
-      "version": "7.1.2-alpha.1",
+      "name": "@edunext/frontend-platform",
+      "version": "7.1.2-alpha-nelc.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cospired/i18n-iso-languages": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@edx/frontend-platform",
-  "version": "7.1.2-alpha.1",
+  "name": "@edunext/frontend-platform",
+  "version": "7.1.2-alpha-nelc.1",
   "description": "Foundational application framework for Open edX micro-frontend applications.",
   "main": "index.js",
   "publishConfig": {


### PR DESCRIPTION
**Description:**

This changes just sets the right version in order to publish the package into the edunext npm account 

https://www.npmjs.com/package/@edunext/frontend-platform/v/7.1.2-alpha-nelc.1
