### PR TITLE
feat(i18n): add language preference management functionality

### DIFF
--- a/src/i18n/LanguageManager.js
+++ b/src/i18n/LanguageManager.js
@@ -1,0 +1,93 @@
+/**
+ * LanguageManager.js
+ *
+ * Provides utility functions for updating the session language preferences for users.
+ */
+
+import { getConfig } from '../config';
+import { getAuthenticatedHttpClient, getAuthenticatedUser } from '../auth';
+import { convertKeyNames, snakeCaseObject } from '../utils';
+import { getCookies, handleRtl, LOCALE_CHANGED } from './lib';
+import { logError } from '../logging';
+import { publish } from '../pubSub';
+
+/**
+ * Updates user language preferences via the preferences API.
+ *
+ * This function converts preference data to snake_case and formats specific keys
+ * according to backend requirements before sending the PATCH request.
+ *
+ * @param {string} username - The username of the user whose preferences to update.
+ * @param {Object} preferenceData - The preference parameters to update (e.g., { prefLang: 'en' }).
+ * @returns {Promise} - A promise that resolves when the API call completes successfully,
+ *                      or rejects if there's an error with the request.
+ */
+export async function updateUserPreferences(username, preferenceData) {
+  const snakeCaseData = snakeCaseObject(preferenceData);
+  const formattedData = convertKeyNames(snakeCaseData, {
+    pref_lang: 'pref-lang',
+  });
+
+  return getAuthenticatedHttpClient().patch(
+    `${getConfig().LMS_BASE_URL}/api/user/v1/preferences/${username}`,
+    formattedData,
+    { headers: { 'Content-Type': 'application/merge-patch+json' } },
+  );
+}
+
+/**
+ * Sets the language for the current session using the setlang endpoint.
+ *
+ * This function sends a POST request to the LMS setlang endpoint to change
+ * the language for the current user session.
+ *
+ * @param {string} languageCode - The language code to set (e.g., 'en', 'es', 'ar').
+ *                               Should be a valid ISO language code supported by the platform.
+ * @returns {Promise} - A promise that resolves when the API call completes successfully,
+ *                      or rejects if there's an error with the request.
+ */
+export async function setSessionLanguage(languageCode) {
+  const formData = new FormData();
+  formData.append('language', languageCode);
+
+  const url = `${getConfig().LMS_BASE_URL}/i18n/setlang/`;
+  return getAuthenticatedHttpClient().post(url, formData, {
+    headers: {
+      Accept: 'application/json',
+      'X-Requested-With': 'XMLHttpRequest',
+    },
+  });
+}
+
+/**
+ * Changes the user's language preference and applies it to the current session.
+ *
+ * This comprehensive function handles the complete language change process:
+ * 1. Sets the language cookie with the selected language code
+ * 2. If a user is authenticated, updates their server-side preference in the backend
+ * 3. Updates the session language through the setlang endpoint
+ * 4. Publishes a locale change event to notify other parts of the application
+ *
+ * @param {string} languageCode - The selected language locale code (e.g., 'en', 'es', 'ar').
+ *                               Should be a valid ISO language code supported by the platform.
+ * @returns {Promise} - A promise that resolves when all operations complete.
+ *
+ */
+export async function changeUserSessionLanguage(languageCode) {
+  const cookies = getCookies();
+  const cookieName = getConfig().LANGUAGE_PREFERENCE_COOKIE_NAME;
+  cookies.set(cookieName, languageCode);
+
+  try {
+    const user = getAuthenticatedUser();
+    if (user) {
+      await updateUserPreferences(user.username, { prefLang: languageCode });
+    }
+
+    await setSessionLanguage(languageCode);
+    handleRtl(languageCode);
+    publish(LOCALE_CHANGED, languageCode);
+  } catch (error) {
+    logError(error);
+  }
+}

--- a/src/i18n/LanguageManager.js
+++ b/src/i18n/LanguageManager.js
@@ -90,4 +90,10 @@ export async function changeUserSessionLanguage(languageCode) {
   } catch (error) {
     logError(error);
   }
+
+  // Force page reload to ensure complete translation application.
+  // While some translations update via the publish event, many sections
+  // of the platform are not configured to receive these events or
+  // handle translations dynamically, requiring a full reload for consistency.
+  window.location.reload();
 }

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -125,4 +125,4 @@ export {
 
 export {
   changeUserSessionLanguage,
-} from './LanguageManager';
+} from './languageManager';

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -122,3 +122,7 @@ export {
   getLanguageList,
   getLanguageMessages,
 } from './languages';
+
+export {
+  changeUserSessionLanguage,
+} from './LanguageManager';

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -102,7 +102,7 @@ export {
   getPrimaryLanguageSubtag,
   getLocale,
   getMessages,
-  getSupportedLocales,
+  getSupportedLocaleList,
   isRtl,
   handleRtl,
   mergeMessages,

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -102,6 +102,7 @@ export {
   getPrimaryLanguageSubtag,
   getLocale,
   getMessages,
+  getSupportedLocales,
   isRtl,
   handleRtl,
   mergeMessages,

--- a/src/i18n/languageApi.js
+++ b/src/i18n/languageApi.js
@@ -1,0 +1,54 @@
+import { getConfig } from '../config';
+import { getAuthenticatedHttpClient } from '../auth';
+import { convertKeyNames, snakeCaseObject } from '../utils';
+
+/**
+ * Updates user language preferences via the preferences API.
+ *
+ * This function converts preference data to snake_case and formats specific keys
+ * according to backend requirements before sending the PATCH request.
+ *
+ * @param {string} username - The username of the user whose preferences to update.
+ * @param {Object} preferenceData - The preference parameters to update (e.g., { prefLang: 'en' }).
+ * @returns {Promise} - A promise that resolves when the API call completes successfully,
+ *                      or rejects if there's an error with the request.
+ */
+export async function updateUserPreferences(username, preferenceData) {
+  const snakeCaseData = snakeCaseObject(preferenceData);
+  const formattedData = convertKeyNames(snakeCaseData, {
+    pref_lang: 'pref-lang',
+  });
+
+  return getAuthenticatedHttpClient().patch(
+    `${getConfig().LMS_BASE_URL}/api/user/v1/preferences/${username}`,
+    formattedData,
+    { headers: { 'Content-Type': 'application/merge-patch+json' } },
+  );
+}
+
+/**
+ * Sets the language for the current session using the setlang endpoint.
+ *
+ * This function sends a POST request to the LMS setlang endpoint to change
+ * the language for the current user session.
+ *
+ * @param {string} languageCode - The language code to set (e.g., 'en', 'es', 'ar').
+ *                               Should be a valid ISO language code supported by the platform.
+ * @returns {Promise} - A promise that resolves when the API call completes successfully,
+ *                      or rejects if there's an error with the request.
+ */
+export async function setSessionLanguage(languageCode) {
+  const formData = new FormData();
+  formData.append('language', languageCode);
+
+  return getAuthenticatedHttpClient().post(
+    `${getConfig().LMS_BASE_URL}/i18n/setlang/`,
+    formData,
+    {
+      headers: {
+        Accept: 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+      },
+    },
+  );
+}

--- a/src/i18n/languageApi.js
+++ b/src/i18n/languageApi.js
@@ -5,7 +5,7 @@ import { convertKeyNames, snakeCaseObject } from '../utils';
 /**
  * Updates user language preferences via the preferences API.
  *
- * This function gets the authenticated user, converts preference data to snake_case 
+ * This function gets the authenticated user, converts preference data to snake_case
  * and formats specific keys according to backend requirements before sending the PATCH request.
  * If no user is authenticated, the function returns early without making the API call.
  *

--- a/src/i18n/languageApi.test.js
+++ b/src/i18n/languageApi.test.js
@@ -1,0 +1,45 @@
+import { updateUserPreferences, setSessionLanguage } from './languageApi';
+import { getConfig } from '../config';
+import { getAuthenticatedHttpClient } from '../auth';
+
+jest.mock('../config');
+jest.mock('../auth');
+
+const LMS_BASE_URL = 'http://test.lms';
+
+describe('languageApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getConfig.mockReturnValue({ LMS_BASE_URL });
+  });
+
+  describe('updateUserPreferences', () => {
+    it('should send a PATCH request with correct data', async () => {
+      const patchMock = jest.fn().mockResolvedValue({});
+      getAuthenticatedHttpClient.mockReturnValue({ patch: patchMock });
+
+      await updateUserPreferences('user1', { prefLang: 'es' });
+
+      expect(patchMock).toHaveBeenCalledWith(
+        `${LMS_BASE_URL}/api/user/v1/preferences/user1`,
+        expect.any(Object),
+        expect.objectContaining({ headers: expect.any(Object) }),
+      );
+    });
+  });
+
+  describe('setSessionLanguage', () => {
+    it('should send a POST request to setlang endpoint', async () => {
+      const postMock = jest.fn().mockResolvedValue({});
+      getAuthenticatedHttpClient.mockReturnValue({ post: postMock });
+
+      await setSessionLanguage('ar');
+
+      expect(postMock).toHaveBeenCalledWith(
+        `${LMS_BASE_URL}/i18n/setlang/`,
+        expect.any(FormData),
+        expect.objectContaining({ headers: expect.any(Object) }),
+      );
+    });
+  });
+});

--- a/src/i18n/languageManager.js
+++ b/src/i18n/languageManager.js
@@ -1,63 +1,9 @@
-/**
- * LanguageManager.js
- *
- * Provides utility functions for updating the session language preferences for users.
- */
-
 import { getConfig } from '../config';
-import { getAuthenticatedHttpClient, getAuthenticatedUser } from '../auth';
-import { convertKeyNames, snakeCaseObject } from '../utils';
+import { getAuthenticatedUser } from '../auth';
 import { getCookies, handleRtl, LOCALE_CHANGED } from './lib';
-import { logError } from '../logging';
 import { publish } from '../pubSub';
-
-/**
- * Updates user language preferences via the preferences API.
- *
- * This function converts preference data to snake_case and formats specific keys
- * according to backend requirements before sending the PATCH request.
- *
- * @param {string} username - The username of the user whose preferences to update.
- * @param {Object} preferenceData - The preference parameters to update (e.g., { prefLang: 'en' }).
- * @returns {Promise} - A promise that resolves when the API call completes successfully,
- *                      or rejects if there's an error with the request.
- */
-export async function updateUserPreferences(username, preferenceData) {
-  const snakeCaseData = snakeCaseObject(preferenceData);
-  const formattedData = convertKeyNames(snakeCaseData, {
-    pref_lang: 'pref-lang',
-  });
-
-  return getAuthenticatedHttpClient().patch(
-    `${getConfig().LMS_BASE_URL}/api/user/v1/preferences/${username}`,
-    formattedData,
-    { headers: { 'Content-Type': 'application/merge-patch+json' } },
-  );
-}
-
-/**
- * Sets the language for the current session using the setlang endpoint.
- *
- * This function sends a POST request to the LMS setlang endpoint to change
- * the language for the current user session.
- *
- * @param {string} languageCode - The language code to set (e.g., 'en', 'es', 'ar').
- *                               Should be a valid ISO language code supported by the platform.
- * @returns {Promise} - A promise that resolves when the API call completes successfully,
- *                      or rejects if there's an error with the request.
- */
-export async function setSessionLanguage(languageCode) {
-  const formData = new FormData();
-  formData.append('language', languageCode);
-
-  const url = `${getConfig().LMS_BASE_URL}/i18n/setlang/`;
-  return getAuthenticatedHttpClient().post(url, formData, {
-    headers: {
-      Accept: 'application/json',
-      'X-Requested-With': 'XMLHttpRequest',
-    },
-  });
-}
+import { logError } from '../logging';
+import { updateUserPreferences, setSessionLanguage } from './languageApi';
 
 /**
  * Changes the user's language preference and applies it to the current session.

--- a/src/i18n/languageManager.js
+++ b/src/i18n/languageManager.js
@@ -70,10 +70,14 @@ export async function setSessionLanguage(languageCode) {
  *
  * @param {string} languageCode - The selected language locale code (e.g., 'en', 'es', 'ar').
  *                               Should be a valid ISO language code supported by the platform.
+ * @param {boolean} [forceReload=false] - Whether to force a page reload after changing the language.
  * @returns {Promise} - A promise that resolves when all operations complete.
  *
  */
-export async function changeUserSessionLanguage(languageCode) {
+export async function changeUserSessionLanguage(
+  languageCode,
+  forceReload = false,
+) {
   const cookies = getCookies();
   const cookieName = getConfig().LANGUAGE_PREFERENCE_COOKIE_NAME;
   cookies.set(cookieName, languageCode);
@@ -91,9 +95,7 @@ export async function changeUserSessionLanguage(languageCode) {
     logError(error);
   }
 
-  // Force page reload to ensure complete translation application.
-  // While some translations update via the publish event, many sections
-  // of the platform are not configured to receive these events or
-  // handle translations dynamically, requiring a full reload for consistency.
-  window.location.reload();
+  if (forceReload) {
+    window.location.reload();
+  }
 }

--- a/src/i18n/languageManager.js
+++ b/src/i18n/languageManager.js
@@ -1,9 +1,8 @@
 import { getConfig } from '../config';
-import { getAuthenticatedUser } from '../auth';
 import { getCookies, handleRtl, LOCALE_CHANGED } from './lib';
 import { publish } from '../pubSub';
 import { logError } from '../logging';
-import { updateUserPreferences, setSessionLanguage } from './languageApi';
+import { updateAuthenticatedUserPreferences, setSessionLanguage } from './languageApi';
 
 /**
  * Changes the user's language preference and applies it to the current session.
@@ -29,11 +28,7 @@ export async function changeUserSessionLanguage(
   cookies.set(cookieName, languageCode);
 
   try {
-    const user = getAuthenticatedUser();
-    if (user) {
-      await updateUserPreferences(user.username, { prefLang: languageCode });
-    }
-
+    await updateAuthenticatedUserPreferences({ prefLang: languageCode });
     await setSessionLanguage(languageCode);
     handleRtl(languageCode);
     publish(LOCALE_CHANGED, languageCode);

--- a/src/i18n/languageManager.test.js
+++ b/src/i18n/languageManager.test.js
@@ -1,0 +1,82 @@
+import { changeUserSessionLanguage } from './languageManager';
+import { getConfig } from '../config';
+import { getAuthenticatedUser } from '../auth';
+import { getCookies, handleRtl, LOCALE_CHANGED } from './lib';
+import { logError } from '../logging';
+import { publish } from '../pubSub';
+import { updateUserPreferences, setSessionLanguage } from './languageApi';
+
+jest.mock('../config');
+jest.mock('../auth');
+jest.mock('./lib');
+jest.mock('../logging');
+jest.mock('../pubSub');
+jest.mock('./languageApi');
+
+const LMS_BASE_URL = 'http://test.lms';
+const LANGUAGE_PREFERENCE_COOKIE_NAME = 'lang';
+
+describe('languageManager', () => {
+  let mockCookies;
+  let mockUser;
+  let mockReload;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getConfig.mockReturnValue({
+      LMS_BASE_URL,
+      LANGUAGE_PREFERENCE_COOKIE_NAME,
+    });
+
+    mockCookies = { set: jest.fn() };
+    getCookies.mockReturnValue(mockCookies);
+
+    mockUser = { username: 'testuser', userId: '123' };
+    getAuthenticatedUser.mockReturnValue(mockUser);
+
+    mockReload = jest.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { reload: mockReload },
+    });
+
+    updateUserPreferences.mockResolvedValue({});
+    setSessionLanguage.mockResolvedValue({});
+  });
+
+  describe('changeUserSessionLanguage', () => {
+    it('should perform complete language change process', async () => {
+      await changeUserSessionLanguage('fr');
+
+      expect(getCookies().set).toHaveBeenCalledWith(
+        LANGUAGE_PREFERENCE_COOKIE_NAME,
+        'fr',
+      );
+      expect(updateUserPreferences).toHaveBeenCalledWith('testuser', {
+        prefLang: 'fr',
+      });
+      expect(setSessionLanguage).toHaveBeenCalledWith('fr');
+      expect(handleRtl).toHaveBeenCalledWith('fr');
+      expect(publish).toHaveBeenCalledWith(LOCALE_CHANGED, 'fr');
+      expect(mockReload).not.toHaveBeenCalled();
+    });
+
+    it('should handle errors gracefully', async () => {
+      updateUserPreferences.mockRejectedValue(new Error('fail'));
+      await changeUserSessionLanguage('es', true);
+      expect(logError).toHaveBeenCalled();
+    });
+
+    it('should skip updateUserPreferences if user is not authenticated', async () => {
+      getAuthenticatedUser.mockReturnValue(null);
+      await changeUserSessionLanguage('en', true);
+      expect(updateUserPreferences).not.toHaveBeenCalled();
+    });
+
+    it('should reload if forceReload is true', async () => {
+      await changeUserSessionLanguage('de', true);
+      expect(mockReload).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/i18n/lib.js
+++ b/src/i18n/lib.js
@@ -182,6 +182,22 @@ export function getMessages(locale = getLocale()) {
 }
 
 /**
+ * Returns the list of supported locales based on the configured messages.
+ * This list is dynamically generated from the translation messages that were
+ * provided during i18n configuration.
+ *
+ * @throws An error if i18n has not yet been configured.
+ * @returns {string[]} Array of supported locale codes
+ * @memberof module:Internationalization
+ */
+export function getSupportedLocales() {
+  if (messages === null) {
+    throw new Error('getSupportedLocales called before configuring i18n. Call configure with messages first.');
+  }
+  return Object.keys(messages);
+}
+
+/**
  * Determines if the provided locale is a right-to-left language.
  *
  * @param {string} locale

--- a/src/i18n/lib.js
+++ b/src/i18n/lib.js
@@ -184,17 +184,23 @@ export function getMessages(locale = getLocale()) {
 /**
  * Returns the list of supported locales based on the configured messages.
  * This list is dynamically generated from the translation messages that were
- * provided during i18n configuration.
+ * provided during i18n configuration. Always includes the current locale.
  *
  * @throws An error if i18n has not yet been configured.
  * @returns {string[]} Array of supported locale codes
  * @memberof module:Internationalization
  */
-export function getSupportedLocales() {
+export function getSupportedLocaleList() {
   if (messages === null) {
-    throw new Error('getSupportedLocales called before configuring i18n. Call configure with messages first.');
+    throw new Error('getSupportedLocaleList called before configuring i18n. Call configure with messages first.');
   }
-  return Object.keys(messages);
+
+  const locales = Object.keys(messages);
+  if (!locales.includes('en')) {
+    locales.push('en');
+  }
+
+  return locales;
 }
 
 /**

--- a/src/i18n/lib.test.js
+++ b/src/i18n/lib.test.js
@@ -4,7 +4,7 @@ import {
   getPrimaryLanguageSubtag,
   getLocale,
   getMessages,
-  getSupportedLocales,
+  getSupportedLocaleList,
   isRtl,
   handleRtl,
   getCookies,
@@ -185,36 +185,28 @@ describe('lib', () => {
   });
 
   describe('getSupportedLocales', () => {
-    beforeEach(() => {
-      configure({
-        loggingService: { logError: jest.fn() },
-        config: {
-          ENVIRONMENT: 'production',
-          LANGUAGE_PREFERENCE_COOKIE_NAME: 'yum',
-        },
-        messages: {
-          'es-419': { message: 'es-hah' },
-          de: { message: 'de-hah' },
-          'en-us': { message: 'en-us-hah' },
-          fr: { message: 'fr-hah' },
-        },
+    describe('when configured', () => {
+      beforeEach(() => {
+        configure({
+          loggingService: { logError: jest.fn() },
+          config: {
+            ENVIRONMENT: 'production',
+            LANGUAGE_PREFERENCE_COOKIE_NAME: 'yum',
+          },
+          messages: {
+            'es-419': { message: 'es-hah' },
+            de: { message: 'de-hah' },
+            'en-us': { message: 'en-us-hah' },
+            fr: { message: 'fr-hah' },
+          },
+        });
       });
-    });
 
-    it('should return an array of supported locale codes', () => {
-      const supportedLocales = getSupportedLocales();
-      expect(Array.isArray(supportedLocales)).toBe(true);
-      expect(supportedLocales).toEqual(['es-419', 'de', 'en-us', 'fr']);
-    });
-
-    it('should throw an error if i18n is not configured', () => {
-      // Reset the configuration to null
-      jest.resetModules();
-      const { getSupportedLocales: freshGetSupportedLocales } = require('./lib');
-      
-      expect(() => freshGetSupportedLocales()).toThrow(
-        'getSupportedLocales called before configuring i18n. Call configure with messages first.'
-      );
+      it('should return an array of supported locale codes', () => {
+        const supportedLocales = getSupportedLocaleList();
+        expect(Array.isArray(supportedLocales)).toBe(true);
+        expect(supportedLocales).toEqual(['es-419', 'de', 'en-us', 'fr', 'en']);
+      });
     });
   });
 

--- a/src/i18n/lib.test.js
+++ b/src/i18n/lib.test.js
@@ -4,6 +4,7 @@ import {
   getPrimaryLanguageSubtag,
   getLocale,
   getMessages,
+  getSupportedLocales,
   isRtl,
   handleRtl,
   getCookies,
@@ -180,6 +181,40 @@ describe('lib', () => {
 
     it('should return the messages for the preferred locale if no argument is passed', () => {
       expect(getMessages().message).toEqual('es-hah');
+    });
+  });
+
+  describe('getSupportedLocales', () => {
+    beforeEach(() => {
+      configure({
+        loggingService: { logError: jest.fn() },
+        config: {
+          ENVIRONMENT: 'production',
+          LANGUAGE_PREFERENCE_COOKIE_NAME: 'yum',
+        },
+        messages: {
+          'es-419': { message: 'es-hah' },
+          de: { message: 'de-hah' },
+          'en-us': { message: 'en-us-hah' },
+          fr: { message: 'fr-hah' },
+        },
+      });
+    });
+
+    it('should return an array of supported locale codes', () => {
+      const supportedLocales = getSupportedLocales();
+      expect(Array.isArray(supportedLocales)).toBe(true);
+      expect(supportedLocales).toEqual(['es-419', 'de', 'en-us', 'fr']);
+    });
+
+    it('should throw an error if i18n is not configured', () => {
+      // Reset the configuration to null
+      jest.resetModules();
+      const { getSupportedLocales: freshGetSupportedLocales } = require('./lib');
+      
+      expect(() => freshGetSupportedLocales()).toThrow(
+        'getSupportedLocales called before configuring i18n. Call configure with messages first.'
+      );
     });
   });
 


### PR DESCRIPTION
**Description:**

This is a backport from https://github.com/openedx/frontend-platform/pull/786

[Issue # 1452](https://edunext.atlassian.net/browse/FUTUREX-1452)

## How to test
Please follow the instructions of this pr https://github.com/nelc/frontend-component-header/pull/6
